### PR TITLE
Backfill repro run metadata by repo

### DIFF
--- a/__tests__/convex/reproRuns.test.ts
+++ b/__tests__/convex/reproRuns.test.ts
@@ -9,6 +9,22 @@ import {
   seedRun,
   seedUser,
 } from "@/test-support/convex/testHelpers";
+import { anyApi, type FunctionReference } from "convex/server";
+
+const runReproRunMetadataBackfill =
+  anyApi.migrations.runReproRunMetadataBackfill as FunctionReference<
+    "mutation",
+    "internal",
+    {
+      fn?: string;
+      cursor?: string | null;
+      batchSize?: number;
+      dryRun?: boolean;
+      next?: string[];
+      reset?: boolean;
+    },
+    unknown
+  >;
 
 function buildReproRun(
   overrides: Partial<{
@@ -188,6 +204,96 @@ describe("reproRuns.listByRepo", () => {
       olderRunId,
     ]);
     expect(results.map((reproRun) => Number(reproRun.iteration))).toEqual([2, 1]);
+  });
+
+  it("backfills run repro metadata and marks the repo complete", async () => {
+    const t = createTestConvex();
+    const { userId, asUser } = await seedUser(t);
+    const installationId = await seedInstallation(t, userId);
+    const { repoId } = await seedRepo(t, { userId, installationId });
+    const olderIssueId = await seedIssue(t, repoId, {
+      githubIssueNumber: BigInt(12),
+    });
+    const newerIssueId = await seedIssue(t, repoId, {
+      githubIssueNumber: BigInt(13),
+    });
+    const olderRunId = await seedRun(t, {
+      userId,
+      repoId,
+      issueId: olderIssueId,
+      runId: "backfill_old",
+      startedAt: 12_000,
+    });
+    const newerRunId = await seedRun(t, {
+      userId,
+      repoId,
+      issueId: newerIssueId,
+      runId: "backfill_new",
+      startedAt: 13_000,
+    });
+
+    const olderReproRunId = await t.run(async (ctx) => {
+      return await ctx.db.insert("reproRuns", {
+        runId: olderRunId,
+        schemaVersion: "rb.repro_run.v1",
+        iteration: BigInt(1),
+        sandbox: {
+          kind: "docker",
+          network: "disabled",
+        },
+        steps: [],
+        artifactContent: "older",
+        durationMs: BigInt(1_000),
+        createdAt: 12_500,
+      });
+    });
+    const newerReproRunId = await t.run(async (ctx) => {
+      return await ctx.db.insert("reproRuns", {
+        runId: newerRunId,
+        schemaVersion: "rb.repro_run.v1",
+        iteration: BigInt(1),
+        sandbox: {
+          kind: "docker",
+          network: "disabled",
+        },
+        steps: [],
+        artifactContent: "newer",
+        durationMs: BigInt(1_000),
+        createdAt: 13_500,
+      });
+    });
+
+    const beforeBackfill = await asUser.query(api.reproRuns.listByRepo, {
+      repoId,
+      limit: 10,
+    });
+    expect(beforeBackfill.map((reproRun) => reproRun.runId)).toEqual([
+      newerRunId,
+      olderRunId,
+    ]);
+
+    await t.mutation(runReproRunMetadataBackfill, {
+      fn: "migrations:backfillRunReproMetadata",
+      next: ["migrations:markReposWithReproMetadataBackfill"],
+    });
+
+    const repo = await t.query(internal.repos.getById, { repoId });
+    const olderRun = await t.query(internal.runs.getById, { runId: olderRunId });
+    const newerRun = await t.query(internal.runs.getById, { runId: newerRunId });
+    const afterBackfill = await asUser.query(api.reproRuns.listByRepo, {
+      repoId,
+      limit: 10,
+    });
+
+    expect(repo?.reproRunMetadataBackfilledAt).toBeTypeOf("number");
+    expect(olderRun?.hasReproRun).toBe(true);
+    expect(olderRun?.latestReproRunId).toBe(olderReproRunId);
+    expect(newerRun?.hasReproRun).toBe(true);
+    expect(newerRun?.latestReproRunId).toBe(newerReproRunId);
+    expect(afterBackfill.map((reproRun) => reproRun.runId)).toEqual([
+      newerRunId,
+      olderRunId,
+    ]);
   });
 
   it("falls back when the denormalized latest repro pointer targets another run", async () => {

--- a/convex/migrations.ts
+++ b/convex/migrations.ts
@@ -1,0 +1,58 @@
+import { Migrations } from "@convex-dev/migrations";
+
+import { components } from "./_generated/api";
+import type { DataModel } from "./_generated/dataModel";
+
+export const migrations = new Migrations<DataModel>(components.migrations);
+
+export const backfillRunReproMetadata = migrations.define({
+  table: "runs",
+  migrateOne: async (ctx, run) => {
+    const latestReproRun = await ctx.db
+      .query("reproRuns")
+      .withIndex("by_run", (query) => query.eq("runId", run._id))
+      .order("desc")
+      .first();
+
+    if (!latestReproRun) {
+      if (
+        run.hasReproRun === undefined &&
+        run.latestReproRunId === undefined
+      ) {
+        return;
+      }
+
+      return {
+        hasReproRun: undefined,
+        latestReproRunId: undefined,
+      };
+    }
+
+    if (
+      run.hasReproRun === true &&
+      run.latestReproRunId === latestReproRun._id
+    ) {
+      return;
+    }
+
+    return {
+      hasReproRun: true,
+      latestReproRunId: latestReproRun._id,
+    };
+  },
+});
+
+export const markReposWithReproMetadataBackfill = migrations.define({
+  table: "repos",
+  migrateOne: (_ctx, repo) => {
+    if (repo.reproRunMetadataBackfilledAt !== undefined) {
+      return;
+    }
+
+    return {
+      reproRunMetadataBackfilledAt: Date.now(),
+    };
+  },
+});
+
+export const runReproRunMetadataBackfill = migrations.runner();

--- a/convex/repos.ts
+++ b/convex/repos.ts
@@ -100,6 +100,7 @@ export const create = mutation({
       defaultBranch: args.defaultBranch,
       ...(args.language !== undefined ? { language: args.language } : {}),
       isActive: true,
+      reproRunMetadataBackfilledAt: now,
       createdAt: now,
       updatedAt: now,
     });
@@ -143,6 +144,12 @@ export const syncFromGitHub = mutation({
         defaultBranch: repo.defaultBranch,
         ...(repo.language !== undefined ? { language: repo.language } : {}),
         isActive: existing?.isActive ?? true,
+        ...(existing?.reproRunMetadataBackfilledAt !== undefined
+          ? {
+              reproRunMetadataBackfilledAt:
+                existing.reproRunMetadataBackfilledAt,
+            }
+          : {}),
         updatedAt: now,
       };
 
@@ -157,6 +164,7 @@ export const syncFromGitHub = mutation({
 
       const repoId = await ctx.db.insert("repos", {
         ...nextRepo,
+        reproRunMetadataBackfilledAt: now,
         createdAt: now,
       });
       await insertDefaultRepoSettings(ctx, repoId);

--- a/convex/reproRuns.ts
+++ b/convex/reproRuns.ts
@@ -119,7 +119,7 @@ export const listByRepo = query({
     limit: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    await requireRepoAccess(ctx, args.repoId);
+    const { repo } = await requireRepoAccess(ctx, args.repoId);
 
     const limit = normalizeLimit(args.limit);
     const indexedRuns = await ctx.db
@@ -152,6 +152,10 @@ export const listByRepo = query({
     );
 
     if (indexedEntries.length >= limit) {
+      return indexedEntries.map((entry) => entry.reproRun);
+    }
+
+    if (repo.reproRunMetadataBackfilledAt !== undefined) {
       return indexedEntries.map((entry) => entry.reproRun);
     }
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -170,6 +170,7 @@ export default defineSchema({
     defaultBranch: v.string(),
     language: v.optional(v.string()),
     isActive: v.boolean(),
+    reproRunMetadataBackfilledAt: v.optional(v.float64()),
     createdAt: v.float64(),
     updatedAt: v.float64(),
   })

--- a/test-support/convex/testHelpers.ts
+++ b/test-support/convex/testHelpers.ts
@@ -1,3 +1,4 @@
+import { register as registerMigrationsComponent } from "@convex-dev/migrations/test";
 import { convexTest } from "convex-test";
 
 import { api } from "@/convex/_generated/api";
@@ -7,7 +8,9 @@ import schema from "@/convex/schema";
 import { modules } from "./modules";
 
 export function createTestConvex() {
-  return convexTest(schema, modules);
+  const t = convexTest(schema, modules);
+  registerMigrationsComponent(t);
+  return t;
 }
 
 export type RepoButlerTest = ReturnType<typeof createTestConvex>;


### PR DESCRIPTION
## Summary
- add a resumable Convex migration to backfill `runs.hasReproRun` and `runs.latestReproRunId`
- mark repos with `reproRunMetadataBackfilledAt` so `reproRuns.listByRepo` can stop using the legacy fallback once historical data is covered
- add Convex tests for the non-backfilled to backfilled transition and register the migrations component in the shared test harness

## Testing
- `pnpm exec vitest run --config vitest.config.convex.ts __tests__/convex/reproRuns.test.ts __tests__/convex/runs.test.ts`
- `pnpm run typecheck`
- `pnpm exec eslint convex/migrations.ts convex/reproRuns.ts convex/repos.ts convex/schema.ts __tests__/convex/reproRuns.test.ts test-support/convex/testHelpers.ts`

## Linear
- `CV-151`
- https://linear.app/cviom/issue/CV-151/backfill-run-repro-metadata-and-remove-legacy-reprorunslistbyrepo
